### PR TITLE
Upgrade all dependencies - 'lein ancient upgrade :recursive'

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,26 +4,26 @@
   :license {:name "Apache License, Version 2.0"}
   :plugins [[lein-midje "3.2.1"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [io.pedestal/pedestal.service "0.5.3"]
-                 [io.pedestal/pedestal.jetty "0.5.3"]
+                 [io.pedestal/pedestal.service "0.5.7"]
+                 [io.pedestal/pedestal.jetty "0.5.7"]
 
-                 [http-kit "2.2.0"]
-                 [com.stuartsierra/component "0.3.2"]
-                 [prismatic/schema "1.1.7"]
-                 [cheshire "5.8.0"]
-                 [io.aviso/pretty "0.1.34"]
+                 [http-kit "2.3.0"]
+                 [com.stuartsierra/component "0.4.0"]
+                 [prismatic/schema "1.1.12"]
+                 [cheshire "5.9.0"]
+                 [io.aviso/pretty "0.1.37"]
 
-                 [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.22"]
-                 [org.slf4j/jcl-over-slf4j "1.7.22"]
-                 [org.slf4j/log4j-over-slf4j "1.7.22"]]
+                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jul-to-slf4j "1.7.29"]
+                 [org.slf4j/jcl-over-slf4j "1.7.29"]
+                 [org.slf4j/log4j-over-slf4j "1.7.29"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources"]
   :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "basic-microservice-example.server/run-dev"]}
-                   :dependencies [[midje "1.9.1"]
+                   :dependencies [[midje "1.9.9"]
                                   [nubank/selvage "0.0.1"]
-                                  [nubank/matcher-combinators "0.2.4"]
-                                  [io.pedestal/pedestal.service-tools "0.5.3"]]}
+                                  [nubank/matcher-combinators "1.2.5"]
+                                  [io.pedestal/pedestal.service-tools "0.5.7"]]}
              :uberjar {:aot [basic-microservice-example.server]}}
   :main ^{:skip-aot true} basic-microservice-example.server)
 


### PR DESCRIPTION
This fixes all errors caused by using JDK **9**, **10**, **11**. 
_In short_, any error caused by running any JDK newer than **8**.

# Error:
   ``` Caused by: java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter ```

   Reason explained:
> The JAXB APIs are considered to be Java EE APIs, 
    and therefore are no longer contained on the default class path in Java SE 9. 
    In Java 11 they are completely removed from the JDK.

Solution was found here:
    [stack_overflow to the rescue!](https://stackoverflow.com/questions/56779380/clojure-lein-figwheel-and-classnotfoundexception-javax-xml-bind-datatypeconver)

# Solution:
  ``` lein ancient upgrade :recursive```

Step by step:

1. I created a  ~/.lein/profiles.clj with the following content:
      ```clojure
          {:user {:dependencies []
                :injections []
                :plugins [[lein-ancient "0.6.15"]]}}
      ```

1. ```lein ancient upgrade :recursive :print ```
     Which said the following about our project:

     ```clojure
        [org.clojure/clojure ["1.10.1"] is available but we use ["1.9.0"] (use :check-clojure to upgrade)
        [io.pedestal/pedestal.service ["0.5.7"] is available but we use ["0.5.3"]
        [io.pedestal/pedestal.jetty ["0.5.7"] is available but we use ["0.5.3"]
        [http-kit ["2.3.0"] is available but we use ["2.2.0"]
        [com.stuartsierra/component ["0.4.0"] is available but we use ["0.3.2"]
        [prismatic/schema ["1.1.12"] is available but we use ["1.1.7"]
        [cheshire ["5.9.0"] is available but we use ["5.8.0"]
        [io.aviso/pretty ["0.1.37"] is available but we use ["0.1.34"]
        [ch.qos.logback/logback-classic ["1.2.3"] is available but we use ["1.1.8"]
        [org.slf4j/jul-to-slf4j ["1.7.29"] is available but we use ["1.7.22"]
        [org.slf4j/jcl-over-slf4j ["1.7.29"] is available but we use ["1.7.22"]
        [org.slf4j/log4j-over-slf4j ["1.7.29"] is available but we use ["1.7.22"]
        [midje ["1.9.9"] is available but we use ["1.9.1"]
        [nubank/matcher-combinators ["1.2.5"] is available but we use ["0.2.4"]
        [io.pedestal/pedestal.service-tools ["0.5.7"] is available but we use ["0.5.3"]
     ```
3. So, I ran the following command to fix all of this ancient dependencies!
        ```lein ancient upgrade :recursive```
4. :smiley: 
